### PR TITLE
Rename from callData to data

### DIFF
--- a/packages/contracts/deploy/10_offchain_resolver.js
+++ b/packages/contracts/deploy/10_offchain_resolver.js
@@ -6,7 +6,7 @@ module.exports = async ({deployments}) => {
     const owner = signers[0].address;
     const resolver = await deploy('OffchainResolver', {
         from: owner,
-        args: ['http://localhost:8000/{sender}/{callData}.json', ['0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266']],
+        args: ['http://localhost:8000/{sender}/{data}.json', ['0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266']],
         log: true,
     });
     


### PR DESCRIPTION
the template example on both provider and EIP uses data, not callData

https://github.com/smartcontractkit/ccip-read/blob/master/packages/ethers-ccip-read-provider/src/index.ts#L84
https://eips.ethereum.org/EIPS/eip-3668#gateway-interface