### PR TITLE
Add Support for contenthash to the Gateway and Client

### DIFF
--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -24,7 +24,12 @@ const provider = new ethers.providers.JsonRpcProvider(options.provider, {
   let resolver = await provider.getResolver(name);
   let resolveName = await provider.resolveName(name);
   if (resolver) {
+    let content = await resolver.getContentHash();
+
     console.log(`resolver address ${resolver.address}`);
     console.log(`eth address ${resolveName}`);
+    console.log(`content ${content}`);
+  } else {
+    console.log(`resolver not found for ${name}`);
   }
 })();

--- a/packages/gateway/src/json.ts
+++ b/packages/gateway/src/json.ts
@@ -4,11 +4,13 @@ import { readFileSync } from 'fs';
 interface NameData {
   addresses?: { [coinType: number]: string };
   text?: { [key: string]: string };
+  contenthash?: string;
 }
 
 type ZoneData = { [name: string]: NameData };
 
 const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
+const EMPTY_CONTENT_HASH = '0x';
 
 export class JSONDatabase implements Database {
   data: ZoneData;
@@ -47,6 +49,14 @@ export class JSONDatabase implements Database {
       return { value: '', ttl: this.ttl };
     }
     return { value: nameData.text[key], ttl: this.ttl };
+  }
+
+  contenthash(name: string) {
+    const nameData = this.findName(name);
+    if (!nameData || !nameData.contenthash) {
+      return { contenthash: EMPTY_CONTENT_HASH, ttl: this.ttl };
+    }
+    return { contenthash: nameData.contenthash, ttl: this.ttl };
   }
 
   private findName(name: string) {

--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -22,6 +22,9 @@ export interface Database {
     name: string,
     key: string
   ): PromiseOrResult<{ value: string; ttl: number }>;
+  contenthash(
+    name: string
+  ): PromiseOrResult<{ contenthash: string; ttl: number }>;
 }
 
 function decodeDnsName(dnsname: Buffer) {
@@ -54,6 +57,10 @@ const queryHandlers: {
   'text(bytes32,string)': async (db, name, args) => {
     const { value, ttl } = await db.text(name, args[0]);
     return { result: [value], ttl };
+  },
+  'contenthash(bytes32)': async (db, name, _args) => {
+    const { contenthash, ttl } = await db.contenthash(name);
+    return { result: [contenthash], ttl };
   },
 };
 

--- a/packages/gateway/test/e2e.test.ts
+++ b/packages/gateway/test/e2e.test.ts
@@ -185,6 +185,8 @@ const TEST_DB = {
       [ETH_COIN_TYPE]: '0x3456345634563456345634563456345634563456',
     },
     text: { email: 'test@example.com' },
+    contenthash:
+      '0xe40101fa011b20d1de9994b4d039f6548d191eb26786769f580809256b4685ef316805265ea162',
   },
 };
 
@@ -276,6 +278,17 @@ describe('End to end test', () => {
         result
       );
       expect(resultData).to.deep.equal([TEST_DB['test.eth'].text['email']]);
+    });
+    it('resolves calls to contenthash(bytes32)', async () => {
+      const callData = Resolver.encodeFunctionData('contenthash(bytes32)', [
+        ethers.utils.namehash('test.eth'),
+      ]);
+      const result = await resolver.resolve(dnsName('test.eth'), callData);
+      const resultData = Resolver.decodeFunctionResult(
+        'contenthash(bytes32)',
+        result
+      );
+      expect(resultData).to.deep.equal([TEST_DB['test.eth'].contenthash]);
     });
   });
 });

--- a/packages/gateway/test/json.test.ts
+++ b/packages/gateway/test/json.test.ts
@@ -1,6 +1,7 @@
 import { JSONDatabase } from '../src/json';
 import { ETH_COIN_TYPE } from '../src/utils';
 const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
+const EMPTY_CONTENT_HASH = '0x';
 
 const TEST_DB = {
   '*.eth': {
@@ -11,6 +12,7 @@ const TEST_DB = {
       email: 'info@example.com',
       description: 'hello offchainresolver record',
     },
+    contenthash: 'ipfs://QmTeW79w7QQ6Npa3b1d5tANreCDxF2iDaAPsDvW6KtLmfB',
   },
   'test.eth': {
     addresses: {
@@ -55,6 +57,20 @@ describe('JSONDatabase', () => {
 
     expect(db.text('foo.eth', 'description')).toStrictEqual({
       value: TEST_DB['*.eth'].text['description'],
+      ttl: 300,
+    });
+  });
+
+  it('resolves content', () => {
+    expect(db.contenthash('foo.eth')).toStrictEqual({
+      contenthash: TEST_DB['*.eth'].contenthash,
+      ttl: 300,
+    });
+  });
+
+  it('resolves empty contenthash when no contenthash is set', () => {
+    expect(db.contenthash('test.eth')).toStrictEqual({
+      contenthash: EMPTY_CONTENT_HASH,
       ttl: 300,
     });
   });

--- a/packages/gateway/test/server.test.ts
+++ b/packages/gateway/test/server.test.ts
@@ -16,12 +16,16 @@ const TEST_DB = {
       [ETH_COIN_TYPE]: '0x2345234523452345234523452345234523452345',
     },
     text: { email: 'wildcard@example.com' },
+    contenthash:
+      '0xe301017012204edd2984eeaf3ddf50bac238ec95c5713fb40b5e428b508fdbe55d3b9f155ffe',
   },
   'test.eth': {
     addresses: {
       [ETH_COIN_TYPE]: '0x3456345634563456345634563456345634563456',
     },
     text: { email: 'test@example.com' },
+    contenthash:
+      '0xe40101fa011b20d1de9994b4d039f6548d191eb26786769f580809256b4685ef316805265ea162',
   },
 };
 
@@ -213,6 +217,36 @@ describe('makeServer', () => {
       expect(response).toStrictEqual({
         status: 200,
         result: Resolver.encodeFunctionResult('text(bytes32,string)', ['']),
+      });
+    });
+  });
+
+  describe('contenthash(bytes32)', () => {
+    it('resolves exact names', async () => {
+      const response = await makeCall('contenthash(bytes32)', 'test.eth');
+      expect(response).toStrictEqual({
+        status: 200,
+        result: Resolver.encodeFunctionResult('contenthash(bytes32)', [
+          TEST_DB['test.eth'].contenthash,
+        ]),
+      });
+    });
+
+    it('resolves wildcard names', async () => {
+      const response = await makeCall('contenthash(bytes32)', 'foo.eth');
+      expect(response).toStrictEqual({
+        status: 200,
+        result: Resolver.encodeFunctionResult('contenthash(bytes32)', [
+          TEST_DB['*.eth'].contenthash,
+        ]),
+      });
+    });
+
+    it('resolves nonexistent names', async () => {
+      const response = await makeCall('contenthash(bytes32)', 'test.test');
+      expect(response).toStrictEqual({
+        status: 200,
+        result: Resolver.encodeFunctionResult('contenthash(bytes32)', ['0x']),
       });
     });
   });


### PR DESCRIPTION
Allows the gateway to respond to contenthash requests.

For simplicity, and preferring precomputing instead of recomputing on every request, the contenthash has to be added to the JSON already encoded. Content can be encoded using [content-hash](https://www.npmjs.com/package/content-hash) or [https://content-hash.surge.sh/](https://content-hash.surge.sh/).