### PR TITLE
Updating named account + instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Serving on port 8000 with signing address 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb9
 
 Take a look at the data in `test.eth.json` under `packages/gateway/`; it specifies addresses for the name `test.eth` and the wildcard `*.test.eth`.
 
-Next, edit `contracts/deploy/10_offchain_resolver.js`; replacing the address on line 9 with the one output when you ran the command above. Then, in a new terminal, build and run a test node with an ENS registry and the offchain resolver deployed:
+Next, edit `packages/contracts/hardhat.config.js`; replacing the address on line 59 with the one output when you ran the command above. Then, in a new terminal, build and run a test node with an ENS registry and the offchain resolver deployed:
 
 ```
 cd packages/contracts

--- a/packages/contracts/deploy/10_offchain_resolver.js
+++ b/packages/contracts/deploy/10_offchain_resolver.js
@@ -2,13 +2,13 @@ const { ethers } = require("hardhat");
 
 module.exports = async ({getNamedAccounts, deployments, network}) => {
     const {deploy} = deployments;
-    const {deployer, owner} = await getNamedAccounts();
+    const {deployer, signer} = await getNamedAccounts();
     if(!network.config.gatewayurl){
         throw("gatewayurl is missing on hardhat.config.js");
     }
     await deploy('OffchainResolver', {
         from: deployer,
-        args: [network.config.gatewayurl, [owner]],
+        args: [network.config.gatewayurl, [signer]],
         log: true,
     });
 };

--- a/packages/contracts/hardhat.config.js
+++ b/packages/contracts/hardhat.config.js
@@ -55,8 +55,8 @@ module.exports = {
     apiKey: process.env.ETHERSCAN_API_KEY
   },
   namedAccounts: {
-    owner: {
-      default: 0,
+    signer: {
+      default: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
     },
     deployer: {
       default: 1,


### PR DESCRIPTION
I believe the initial README instructions were out of date. I updated the `namedAccounts` in the hardhat config to make it clearer what the accounts are used for and the README to refer to the correct location.