### PR TITLE
Add missing btc address to *.test.eth

### DIFF
--- a/packages/gateway/test.eth.json
+++ b/packages/gateway/test.eth.json
@@ -10,7 +10,8 @@
     "*.test.eth": {
         "addresses": {
             "60": "0x70997970c51812dc3a010c7d01b50e0d17dc79c8",
-            "2":  "0xa914b48297bff5dadecc5f36145cec6a5f20d57c8f9b87"
+            "2":  "0xa914b48297bff5dadecc5f36145cec6a5f20d57c8f9b87",
+            "0": "0x007c96701e171f91d3a5a98477c4ead125add88425e4af98c1"
         },
         "text":{ "email": "wildcard@example.com" },
         "contenthash": "0xe301017012204edd2984eeaf3ddf50bac238ec95c5713fb40b5e428b508fdbe55d3b9f155ffe"


### PR DESCRIPTION
Current example would run into resolve error because BTC address of `*.test.eth` is [not supplied](https://github.com/ensdomains/offchain-resolver/blob/ed330e4322b1fafe2ffbd1496829c75185dd9e2e/packages/client/src/index.ts#L27). I fill it in with a random BTC address.
Solves #20 