### PR TITLE
fixed missing byte of signature (64 vs 65)

### DIFF
--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -114,7 +114,7 @@ export function makeServer(signer: ethers.utils.SigningKey, db: Database) {
           ]
         );
         const sig = signer.signDigest(messageHash);
-        const sigData = hexConcat([sig.r, sig._vs]);
+        const sigData = hexConcat([sig.r, sig.s, new Uint8Array([sig.v])]);
         return [result, validUntil, sigData];
       },
     },


### PR DESCRIPTION
This PR addresses an issue with the signature format used in the sigData construction. Previously, the signature was created by concatenating the r and _vs components, resulting in a 64-byte signature. This format worked on the local Hardhat blockchain but was incompatible with public test networks.

The proposed change modifies the signature construction to include all three components of a standard Ethereum signature: the r, s, and v values. This results in a 65-byte signature that is compatible with both the local Hardhat blockchain and public test networks.