### PR TITLE
retrieve signer from extradata for proxy calls

### DIFF
--- a/packages/contracts/contracts/OffchainResolver.sol
+++ b/packages/contracts/contracts/OffchainResolver.sol
@@ -47,7 +47,7 @@ contract OffchainResolver is IExtendedResolver, SupportsInterface {
             urls,
             callData,
             OffchainResolver.resolveWithProof.selector,
-            callData
+            abi.encode(callData, address(this))
         );
     }
 

--- a/packages/contracts/contracts/SignatureVerifier.sol
+++ b/packages/contracts/contracts/SignatureVerifier.sol
@@ -25,7 +25,8 @@ library SignatureVerifier {
      */
     function verify(bytes calldata request, bytes calldata response) internal view returns(address, bytes memory) {
         (bytes memory result, uint64 expires, bytes memory sig) = abi.decode(response, (bytes, uint64, bytes));
-        address signer = ECDSA.recover(makeSignatureHash(address(this), expires, request, result), sig);
+        (bytes memory extraData, address sender) = abi.decode(request, (bytes, address));
+        address signer = ECDSA.recover(makeSignatureHash(sender, expires, extraData, result), sig);
         require(
             expires >= block.timestamp,
             "SignatureVerifier: Signature expired");

--- a/packages/contracts/test/TestOffchainResolver.js
+++ b/packages/contracts/test/TestOffchainResolver.js
@@ -78,9 +78,10 @@ describe('OffchainResolver', function (accounts) {
         it('resolves an address given a valid signature', async () => {
             // Generate the response data
             const response = defaultAbiCoder.encode(['bytes', 'uint64', 'bytes'], [resultData, expires, hexConcat([sig.r, sig._vs])]);
+            const encodedData = ethers.utils.defaultAbiCoder.encode(['bytes', 'address'], [callData, resolver.address]);
 
             // Call the function with the request and response
-            const [result] = iface.decodeFunctionResult("addr", await resolver.resolveWithProof(response, callData));
+            const [result] = iface.decodeFunctionResult("addr", await resolver.resolveWithProof(response, encodedData));
             expect(result).to.equal(TEST_ADDRESS);
         });
 


### PR DESCRIPTION
This change is required in case another contract bubbles up the "offchain lookup error" and makes the call, we will be able to call the callback function and verify the result.